### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# See https://help.github.com/articles/dealing-with-line-endings/
+
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.c text
+*.h text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.sln text eol=crlf
+
+# Preserve Unix line endings on those files (used inside the Linux VM)
+jenkins/plugins.txt text eol=lf
+sonar/run.sh text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+
+# EOF


### PR DESCRIPTION
Make sure that scripts that will be copied into the Docker images
have the correct Unix line endings.

Tested with Docker Toolbox 1.9.1c running on MS Windows 7 64-bit.

Fix https://github.com/marcelbirkner/docker-ci-tool-stack/issues/2

Signed-off-by: Gianpaolo Macario <gmacario@gmail.com>