### PR TITLE
README.md: Fix Link to Jenkins dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ docker-compose up
 
 | *Tool* | *Link* | *Credentials* |
 | ------------- | ------------- | ------------- |
-| Jenkins | http://${docker-machine ip default}:8080/jenkins/ | no login required |
+| Jenkins | http://${docker-machine ip default}:18080/ | no login required |
 | SonarQube | http://${docker-machine ip default}:9000/ | admin/admin |
 | Nexus | http://${docker-machine ip default}:8081/nexus | admin/admin123 |
 | GitLab | http://${docker-machine ip default}:10080/ | root/5iveL!fe |


### PR DESCRIPTION
Adjust documentation to reflect the actual docker-compose.yml

Signed-off-by: Gianpaolo Macario <gmacario@gmail.com>