### PR TITLE
Update to the latest Gitlab version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ postgresql:
   volumes:
     - /srv/docker/gitlab/postgresql:/var/lib/postgresql
 gitlab:
-  image: sameersbn/gitlab:8.0.3
+  image: sameersbn/gitlab:8.3.2
   links:
     - redis:redisio
     - postgresql:postgresql


### PR DESCRIPTION
Hi Marcel,

Just updated the Gitlab image version to 8.3.2 (latest release available).

Local tested and worked without problems :-).