### PR TITLE
Fix redis host name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
     - DB_NAME=gitlab
     - DB_USER=gitlab
     - DB_PASS=gitlab
-    - REDIS_HOST=redisio
+    - REDIS_HOST=redis
 
     - TZ=Europe/Madrid
     - GITLAB_TIMEZONE=Madrid


### PR DESCRIPTION
This is required in order to start the Gitlab container, probably this got lost when replacing the links with the network.