### PR TITLE
Fixed Ubuntu 16.04 build

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -12,7 +12,11 @@ RUN echo "jenkins ALL=NOPASSWD: ALL" >> /etc/sudoers
 # see: https://get.docker.com/builds/
 # see: https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Docker+Custom+Build+Environment+Plugin#CloudBeesDockerCustomBuildEnvironmentPlugin-DockerinDocker
 RUN curl -sSL -O https://get.docker.com/builds/Linux/x86_64/docker-latest.tgz && tar -xvzf docker-latest.tgz
-RUN mv docker/* /usr/bin/
+
+# Next line breaks docker-compose up in ubuntu 16.04. 
+# It seems we could avoid that since we are 
+# mounting /usr/local/bin/docker from docker-compose.yml
+# RUN mv docker/* /usr/bin/
 
 USER jenkins
 


### PR DESCRIPTION
Hi @marcelbirkner!

Using your repo had the next error on `docker-compose up`:

``` shell
ERROR: for jenkins  rpc error: code = 2 desc = "oci runtime error: could not synchronise with container process: not a directory"
Traceback (most recent call last):
  File "/usr/local/bin/docker-compose", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/dist-packages/compose/cli/main.py", line 63, in main
    log.error(e.msg)
AttributeError: 'ProjectError' object has no attribute 'msg'
```

I am no sure If it breaks other places. It is my first contribution to other's repository. I hope having done fine, in case I did anything wrong any advise would be helpful.

Thanks!!
