### PR TITLE
Update Dockerfile

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -11,8 +11,8 @@ RUN echo "jenkins ALL=NOPASSWD: ALL" >> /etc/sudoers
 # see: https://issues.jenkins-ci.org/browse/JENKINS-35025
 # see: https://get.docker.com/builds/
 # see: https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Docker+Custom+Build+Environment+Plugin#CloudBeesDockerCustomBuildEnvironmentPlugin-DockerinDocker
-RUN curl -sSL -O https://get.docker.com/builds/Linux/x86_64/docker-latest.tgz && tar -xvzf docker-latest.tgz
-RUN mv docker/* /usr/bin/
+RUN curl -sSL -o /bin/docker https://get.docker.io/builds/Linux/x86_64/docker-latest 
+RUN chmod +x /bin/docker
 
 USER jenkins
 


### PR DESCRIPTION
dapt dockerfile to allow download the last docker: resolving error--cannot remove ‘docker/completion/bash/docker’: No such file or directory