### PR TITLE
Peg the version of Postgres at 9.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
  sonardb:
   networks:
     - prodnetwork
-  image: postgres
+  image: postgres:9.6
   environment:
    - POSTGRES_USER=sonar
    - POSTGRES_PASSWORD=sonar


### PR DESCRIPTION
Peg the version of Postgres at 9.6 - the latest version that SonarQube supports.